### PR TITLE
Adding syntax comparison before auto saving.

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,7 +133,7 @@ class RunFormatEventListener(sublime_plugin.EventListener):
         formatter = common.settings().get('formatters', {})
         if formatter and isinstance(formatter, dict):
             for key, value in formatter.items():
-                if value.get('format_on_save', False):
+                if value.get('format_on_save', False) and self.view.settings().get('syntax') in value.get('syntaxes', []):
                     view.run_command('run_format', {'identifier': key})
 
     @classmethod


### PR DESCRIPTION
This should fix the issue with auto save throwing a bunch of errors because the syntax doesn't match.