### PR TITLE
Modify Interpreter Lookup Logic and add warning for Black

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -191,8 +191,8 @@ def get_environ_path(fnames):
         environ = update_environ()
         if environ and isinstance(environ, dict):
             paths = environ.get('PATH', '').split(pathsep)
-            for path in paths:
-                for fname in fnames:
+            for fname in fnames:
+                for path in paths:
                     file = join(path, fname)
                     if IS_WINDOWS and not splitext(file)[1]:
                         for extension in ('.exe', '.cmd', '.bat'):

--- a/src/formatter_black.py
+++ b/src/formatter_black.py
@@ -35,6 +35,10 @@ class BlackFormatter:
         if not interpreter or not executable:
             return None
 
+        # black required python 3, warning if interpreter version is unknown
+        if "python3" not in interpreter:
+            log.warning("Using %s as interpreter, make sure it is symlink to python 3", interpreter)
+
         cmd = [interpreter, executable]
 
         args = common.get_args(self.identifier)


### PR DESCRIPTION
```
▋[Formatter](Thread-1154:formatter.py#L83): [DEBUG] Target: (view)
▋[Formatter](Thread-1154:formatter.py#L84): [DEBUG] Scope: source.python meta.function.python storage.type.function.python 
▋[Formatter](Thread-1154:formatter.py#L85): [DEBUG] Syntax: python
▋[Formatter](Thread-1154:formatter.py#L86): [DEBUG] Formatter ID: black
▋[Formatter](Thread-1154:common.py#L215): [DEBUG] Interpreter: /usr/local/bin/python
▋[Formatter](Thread-1154:common.py#L226): [DEBUG] Executable: /Users/tomy0000000/.pyenv/versions/3.7.4/bin/black
▋[Formatter](Thread-1154:common.py#L249): [DEBUG] Config [default]: /Users/tomy0000000/Library/Application Support/Sublime Text 3/Packages/User/formatter.assets/config/blackrc.toml
▋[Formatter](Thread-1154:formatter_black.py#L64): [ERROR] File not formatted due to an error (errno=1): "Traceback (most recent call last):
  File "/Users/tomy0000000/.pyenv/versions/3.7.4/bin/black", line 5, in <module>
    from black import patched_main
  File "/Users/tomy0000000/.pyenv/versions/3.7.4/lib/python3.7/site-packages/black.py", line 104
    def from_configuration(cls, *, check: bool, diff: bool) -> "WriteBack":
                                 ^
SyntaxError: invalid syntax
"
▋[Formatter](Thread-1154:main.py#L118): [DEBUG] Formatting failed. 💣💥😢
```

Black does not support Python 2.

When Formatter resolve interpreter,
even `python3` exists (perhaps in somewhere far back of `PATH`)
`python` in the front lines will be returned.
Which is Python 2, most of the time.

This can be a huge problem,
as user can't even find out simply by observing the debug logs.

Even if they did guess out the problem,
editing settings won't solve the problem because the current logic tends to return the wrong interpreter.

A temporarily fix for user would be **symlink python3** to first few `PATH` directory.
Say you have a `PATH` of `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`,
symlink python3 to `/usr/local/bin` will fix the problem for now.