### PR TITLE
Update formatter_phpcsfixer.py

### DIFF
--- a/src/formatter_phpcsfixer.py
+++ b/src/formatter_phpcsfixer.py
@@ -33,7 +33,7 @@ class PhpcsfixerFormatter:
         try:
             php = common.get_interpreter_path(INTERPRETER_NAMES)
             if php:
-                proc = common.exec_cmd([php, '-v'], self.pathinfo[0])
+                proc = common.exec_cmd([php, '-v'], self.pathinfo[1])
                 stdout = proc.communicate()[0]
                 string = stdout.decode('utf-8')
                 version = string.splitlines()[0].split(' ')[1]


### PR DESCRIPTION
`formatter_phpcsfixer.py` is returning error.

![230719-164258](https://github.com/bitst0rm-pub/Formatter/assets/186420/b7429270-6da2-46fa-b148-0877ab7b8a7a)

I think it is because _current file path_ (`self.pathinfo[0]`) is passed to `exec_cmd(cmd, cwd)` as `cwd` argument

It works fine when I change it to `self.pathinfo[1]`, which is (if I'm not mistaken) current working directory.

Thanks for great plugin! I'm long time user, I don't remember when I installed it : )