### PR TITLE
Simplify type handling in jsbeautifier

### DIFF
--- a/src/formatter_jsbeautifier.py
+++ b/src/formatter_jsbeautifier.py
@@ -35,12 +35,6 @@ class JsbeautifierFormatter:
         if config:
             cmd.extend(['--config', config])
 
-        syntax = common.get_assigned_syntax(self.view, self.identifier, self.region, self.is_selected)
-        typ = 'js' # default
-        if syntax in ('js', 'css', 'html'):
-            typ = syntax
-        cmd.extend(['--type', typ])
-
         return cmd
 
     def format(self, text):


### PR DESCRIPTION
The type-munging logic I've deleted here can cause problems when attempting to specify a narrow scope of syntax (e.g `html.basic`) in order to, for example, target various kinds of markup but not markDOWN. Attempting to override the type selection of this class by injecting args via config fails, as they're added to the cmd _before_ the automatic type selection.

At the plugin config level it's already possible to set the type a.) _implicitly,_  by specifying the executable (as noted at https://github.com/beautify-web/js-beautify#css--html) and, b.) _explicitly,_ with an arg (e.g. `"args": ["--type", "html"]`).

Thus I think it makes sense to remove this logic.