### PR TITLE
Resolve Local Prettier

### DIFF
--- a/modules/formatter_prettier.py
+++ b/modules/formatter_prettier.py
@@ -40,21 +40,24 @@ class PrettierFormatter:
 
     def get_cmd(self):
         cmd = common.get_head_cmd(self.uid, INTERPRETERS, EXECUTABLES)
+        use_local_prettier = False
 
         if not cmd:
             log.debug("Looking for local prettier...")
             exe = self.resolve_prettier_cli()
             if exe:
+                use_local_prettier = True
                 cmd = [exe]
 
         if not cmd:
             return None
 
-        config = common.get_config_path(self.view, self.uid, self.region, self.is_selected)
-        if config:
-            cmd.extend(['--config', config])
-        else:
-            cmd.extend(['--no-config'])
+        if not use_local_prettier:
+            config = common.get_config_path(self.view, self.uid, self.region, self.is_selected)
+            if config:
+                cmd.extend(['--config', config])
+            else:
+                cmd.extend(['--no-config'])
 
         if self.pathinfo['path']:
             cmd.extend(['--stdin-filepath', self.pathinfo['path']])


### PR DESCRIPTION
It's very common to have multiple JS/TS projects, each with a different version of prettier installed. In these cases, it's not particularly useful to have `prettier` installed globally, and there's no _one_ `executable_path` that can be set to resolve the correct `prettier` executable for each project.

This adapts some code from https://github.com/jonlabelle/SublimeJsPrettier to recursively search for a local install of prettier _only_ if there is no global `prettier` executable and `executable_path` is not set.

This search is naive, in that it takes the currently open view, and looks in each directory for known `node_modules` paths for prettier until it finds one or reaches the `os` root directory.